### PR TITLE
feat. 내 프로젝트 페이지의 셀 탭할 경우 프로젝트 디테일 페이지로 이동 구현

### DIFF
--- a/CodeFantasia/MyProject/MyProjectViewModel.swift
+++ b/CodeFantasia/MyProject/MyProjectViewModel.swift
@@ -18,8 +18,8 @@ final class MyProjectViewModel {
         var projectDataFetched: Observable<Project>
     }
     private let disposeBag = DisposeBag()
-     let projectRepository: ProjectRepositoryProtocol
-    private let projectId: String
+    let projectRepository: ProjectRepositoryProtocol
+    let projectId: String
     
     init(
         projectRepository: ProjectRepositoryProtocol,

--- a/CodeFantasia/TabbarM.swift
+++ b/CodeFantasia/TabbarM.swift
@@ -20,13 +20,14 @@ extension UIImage {
 
 
 class TabBarController: UITabBarController {
+    
     override func viewDidLoad() {
         tabBar.isTranslucent = true
         super.viewDidLoad()
         
         let iconSize = CGSize(width: 25, height: 25)
         
-        let tabbarMyProjectVC = UINavigationController(rootViewController: MyProjectVC(viewModel: MyProjectViewModel(projectRepository: ProjectRepository(firebaseBaseManager: FireBaseManager()), projectId: "76A053B9-7104-495A-8917-E6E43BB98602")))
+        let tabbarMyProjectVC = UINavigationController(rootViewController: MyProjectVC(viewModel: MyProjectViewModel(projectRepository: ProjectRepository(firebaseBaseManager: FireBaseManager()), projectId: "CB7598EE-5B02-43EE-8112-B11890E38069")))
         let firstTabIcon = UIImage(named: "TabbarMyProject")?.withRenderingMode(.alwaysOriginal).resize(to: iconSize)
         tabbarMyProjectVC.tabBarItem = UITabBarItem(title: "나의 프로젝트", image: firstTabIcon, tag: 0)
         

--- a/CodeFantasia/To be deleted/MyProjectVC.swift
+++ b/CodeFantasia/To be deleted/MyProjectVC.swift
@@ -3,7 +3,7 @@
 //  CodeFantasia
 //
 //  Created by 서영덕 on 10/13/23.
-//  탭바를 위해 임시로 만든 파일 추후에 프로필 페이지 완성 시 삭제 후 탭바 수정 필요
+
 import UIKit
 import SnapKit
 import Then
@@ -20,7 +20,6 @@ class MyProjectVC: UITableViewController {
         $0.font = UIFont.title
         $0.textColor = .black
     }
-    
     private let viewModel: MyProjectViewModel
     private let disposeBag = DisposeBag()
     
@@ -33,11 +32,15 @@ class MyProjectVC: UITableViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationbarTitle()
-
+        
+        //        let proData = Project(projectTitle: "테스트를 위한 제목",projecSubtitle: "테스트를 위한 부제목(상세내용) 임시 데이터입니다",techStack: [], recruitmentCount: 6, imageUrl: "https://www.navercorp.com/img/ko/og/logo.png",projectID: UUID(), platform: [], teamMember: [])
+        //
+        //        viewModel.projectRepository.create(project: proData)
+        //
         tableView.backgroundColor = UIColor.backgroundColor
         tableView.separatorStyle = .none
         tableView.register(MyProjectTableViewCell.self, forCellReuseIdentifier: MyProjectTableViewCell.identifier)
@@ -47,15 +50,34 @@ class MyProjectVC: UITableViewController {
 }
 
 extension MyProjectVC {
+    private func bind() {
+        let inputs = MyProjectViewModel.Input(
+            viewDidLoad: rx.viewDidLoad.asObservable()
+        )
+        let outputs = viewModel.transform(input: inputs)
+        
+        outputs.projectDataFetched
+            .withUnretained(self)
+            .subscribe(onNext: { owner, project in
+                DispatchQueue.main.async {
+                    owner.projectDataArray.append(project)
+                    self.tableView.reloadData()
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+}
 
+extension MyProjectVC {
+    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return projectDataArray.count
     }
-
+    
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 270
     }
-
+    
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: MyProjectTableViewCell.identifier, for: indexPath) as? MyProjectTableViewCell else { return UITableViewCell() }
         let project = projectDataArray[indexPath.row]
@@ -67,28 +89,14 @@ extension MyProjectVC {
         cell.dateView.backgroundColor = UIColor.buttonPrimaryColor
         return cell
     }
-
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let moveDetail = ProjectDetailNoticeBoardViewController(viewModel: ProjectDetailNoticeBoardViewModel(projectRepository: ProjectRepository(firebaseBaseManager: FireBaseManager()), projectId: viewModel.projectId))
+        self.navigationController?.pushViewController(moveDetail, animated: true)
+    }
+    
     func navigationbarTitle() {
         let barTitleItem = UIBarButtonItem(customView: barTitle)
         navigationItem.leftBarButtonItem = barTitleItem
     }
-}
-extension MyProjectVC {
-private func bind() {
-      let inputs = MyProjectViewModel.Input(
-          viewDidLoad: rx.viewDidLoad.asObservable()
-      )
-      let outputs = viewModel.transform(input: inputs)
-
-      outputs.projectDataFetched
-        .withUnretained(self)
-        .subscribe(onNext: { owner, project in
-            DispatchQueue.main.async {
-                owner.projectDataArray.append(project)
-                self.tableView.reloadData()
-            }
-          })
-          .disposed(by: disposeBag)
-  }
-
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/CF-019-ProfileData -> dev

### 변경 사항
- 내 프로젝트 페이지에서 셀 탭할시 프로젝트 디테일 페이지로 이동

### 기타 사항 

- 프로젝트 디테일 페이지로 이동시 신청하기 버튼이 보이는데 내 프로젝트 페이지에서 이동한 경우라면 이 신청하기 버튼이 안보이게 할 수 있을지?

![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-27 at 19 39 54](https://github.com/CodeFantasia/iOS/assets/139093066/42e64b62-936a-4b4e-b7f3-5603d6b43c14)


### 테스트 결과

https://github.com/CodeFantasia/iOS/assets/139093066/5127965d-86a9-4e6e-8015-ba7c861b6914

### 관련 이슈 

