### PR TITLE
[FEAT] 프로필 페이지 로그인된 유저 정보 불러오기

### DIFF
--- a/CodeFantasia/Profile/ProfileViewModel.swift
+++ b/CodeFantasia/Profile/ProfileViewModel.swift
@@ -15,17 +15,17 @@ final class ProfileViewModel {
     
     struct Input {
         var viewDidLoad: Observable<Void>
-        var profileEditTapped: Observable<Void>
-        var logoutTapped: Observable<Void>
+        var profileEditTapped: Driver<Void>
+        var logoutTapped: Driver<Void>
     }
     struct Output {
         var userDataFetched: Observable<UserProfile>
-        var profileEditDidTap: Observable<Void>
-        var logoutDidTap: Observable<Void>
+        var profileEditDidTap: Driver<Void>
+        var logoutDidTap: Driver<Void>
     }
     private let disposeBag = DisposeBag()
-    let userRepository: UserRepositoryProtocol
-    let userId: String
+    private let userRepository: UserRepositoryProtocol
+    private let userId: String
     
     init(
         userRepository: UserRepositoryProtocol,
@@ -37,7 +37,8 @@ final class ProfileViewModel {
     
     func transform(input: Input) -> Output {
         
-        let userData = Observable<UserProfile>.create { observer in
+        let userData = Observable<UserProfile>.create { [weak self] observer in
+            guard let self else { return Disposables.create() }
             input.viewDidLoad
                 .withUnretained(self)
                 .subscribe { userId in

--- a/CodeFantasia/TabbarM.swift
+++ b/CodeFantasia/TabbarM.swift
@@ -60,18 +60,19 @@ class TabBarController: UITabBarController {
     // MARK: - Helpers
     
     func configureUI() {
+        let userId = Auth.auth().currentUser?.uid
         tabBar.isTranslucent = true
         
         let iconSize = CGSize(width: 25, height: 25)
         
-        let tabbarMyProjectVC = UINavigationController(rootViewController: MyProjectVC(viewModel: MyProjectViewModel(projectRepository: ProjectRepository(firebaseBaseManager: FireBaseManager()), projectId: "CB7598EE-5B02-43EE-8112-B11890E38069")))
+        let tabbarMyProjectVC = UINavigationController(rootViewController: MyProjectVC(viewModel: MyProjectViewModel(projectRepository: ProjectRepository(firebaseBaseManager: FireBaseManager()), projectId: userId!)))
         let firstTabIcon = UIImage(named: "TabbarMyProject")?.withRenderingMode(.alwaysOriginal).resize(to: iconSize)
         tabbarMyProjectVC.tabBarItem = UITabBarItem(title: "나의 프로젝트", image: firstTabIcon, tag: 0)
         
         let tabbarMainVC = UINavigationController(rootViewController: ProjectBoardVC())
         let secondTabIcon = UIImage(named: "TabbarHome")?.withRenderingMode(.alwaysOriginal).resize(to: iconSize)
         tabbarMainVC.tabBarItem = UITabBarItem(title: "홈", image: secondTabIcon, tag: 1)
-        let tabbarProfileVC = UINavigationController(rootViewController: ProfileViewController(viewModel: ProfileViewModel(userRepository: UserRepository(firebaseBaseManager: FireBaseManager()), userId: "08CBFD37-5391-4BB8-AF24-3F313590619B")))
+        let tabbarProfileVC = UINavigationController(rootViewController: ProfileViewController(viewModel: ProfileViewModel(userRepository: UserRepository(firebaseBaseManager: FireBaseManager()), userId: userId!)))
         let thirdTabIcon = UIImage(named: "TabbarProfile")?.withRenderingMode(.alwaysOriginal).resize(to: iconSize)
         tabbarProfileVC.tabBarItem = UITabBarItem(title: "프로필", image: thirdTabIcon, tag: 2)
         

--- a/CodeFantasia/To be deleted/MyProjectVC.swift
+++ b/CodeFantasia/To be deleted/MyProjectVC.swift
@@ -37,10 +37,6 @@ class MyProjectVC: UITableViewController {
         super.viewDidLoad()
         navigationbarTitle()
         
-        //        let proData = Project(projectTitle: "테스트를 위한 제목",projecSubtitle: "테스트를 위한 부제목(상세내용) 임시 데이터입니다",techStack: [], recruitmentCount: 6, imageUrl: "https://www.navercorp.com/img/ko/og/logo.png",projectID: UUID(), platform: [], teamMember: [])
-        //
-        //        viewModel.projectRepository.create(project: proData)
-        //
         tableView.backgroundColor = UIColor.backgroundColor
         tableView.separatorStyle = .none
         tableView.register(MyProjectTableViewCell.self, forCellReuseIdentifier: MyProjectTableViewCell.identifier)


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/CF-019-ProfileData -> devlop

### 변경 사항
프로필 페이지에서 로그인된 유저의 정보를 불러오게 구현했습니다.

### 기타 사항 

- 현재 로그인된 유저의 프로필 정보가 등록되지 않아서 오류가 발생합니다

### 테스트 결과
![Simulator Screenshot - iPhone 14 Pro - 2023-11-01 at 19 07 03](https://github.com/CodeFantasia/iOS/assets/139093066/45c3b3a5-6170-4796-9ecd-787306504b26)


### 관련 이슈 

#82