### PR TITLE
[FEAT] 프로필 등록 및 수정 페이지 여러가지 수정, 새글작성 페이지 수정하기시 글복사 해결

### DIFF
--- a/CodeFantasia/Controller/Authentication/SignUp/RegistrationController.swift
+++ b/CodeFantasia/Controller/Authentication/SignUp/RegistrationController.swift
@@ -211,8 +211,9 @@ class RegistrationController: UIViewController {
         AuthManager.shared.registerUser(crudentials: newUser)
         
         print("계정 등록 완료!")
-        
-        let vc = UserDataManageController()
+        let userId = Auth.auth().currentUser?.uid
+        let data = ProfileViewModel(userRepository:UserRepository(firebaseBaseManager: FireBaseManager()), userId: userId ?? "").userProfile
+        let vc = UserDataManageController(data: data)
         vc.hideWithdrawButton()
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/CodeFantasia/Controller/Authentication/UserDataManageController.swift
+++ b/CodeFantasia/Controller/Authentication/UserDataManageController.swift
@@ -4,7 +4,7 @@ import RxSwift
 import Firebase
 import FirebaseAuth
 import FirebaseStorage
-import Kingfisher
+//import Kingfisher
 
 class UserDataManageController: UIViewController {
     

--- a/CodeFantasia/Controller/Authentication/UserDataManageController.swift
+++ b/CodeFantasia/Controller/Authentication/UserDataManageController.swift
@@ -4,10 +4,46 @@ import RxSwift
 import Firebase
 import FirebaseAuth
 import FirebaseStorage
+import Kingfisher
 
 class UserDataManageController: UIViewController {
     
+    let data: UserProfile?
     
+    init(data: UserProfile?) {
+        self.data = data
+        super.init(nibName: nil, bundle: nil)
+    }
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    // 데이터가있는지 판별
+    func setUp() {
+        if let userProfile = data {
+            nicknameTextView.text = userProfile.nickname
+            selfIntroductionTextView.text = userProfile.selfIntroduction
+            portfolioTextView.text = userProfile.portfolioURL
+            techStackTextView.text = userProfile.techStack.joined(separator: ", ")
+            interestTextView.text = userProfile.areasOfInterest.joined(separator: ", ")
+//            if let profileImageURL = URL(string: userProfile.profileImageURL ?? "") {
+//                // 백그라운드 스레드에서 이미지 다운로드
+//                DispatchQueue.global().async {
+//                    if let data = try? Data(contentsOf: profileImageURL) {
+//                        if let image = UIImage(data: data) {
+//                            // 메인 스레드에서 UI 업데이트
+//                            DispatchQueue.main.async {
+//                                self.profileImage = image
+//                            }
+//                        }
+//                    }
+//                }
+//            } else {
+//                // URL이 nil일 때의 처리
+//            }
+        } else {
+        }
+    }
     // MARK: - Properties
     
     private var selectedTechStack = [String]()
@@ -137,7 +173,7 @@ class UserDataManageController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        setUp()
         configureNavBar()
         configureUI()
         configureDropdownUI()
@@ -248,10 +284,17 @@ class UserDataManageController: UIViewController {
             techStackView.shake()
         } else if selectedInterestField.isEmpty {
             interestFieldView.shake()
+        } else if portfolioTextView.text.isEmpty || portfolioTextView.text == "포트폴리오 링크를 입력해주세요." {
+            portfolioUrlView.shake()
+        } else if selfIntroductionTextView.text.isEmpty || selfIntroductionTextView.text == "자기 소개를 입력해주세요." {
+            selfIntroductionView.shake()
         } else {
             return true
         }
-
+        let alertController = UIAlertController(title: "프로필 등록 실패", message: "입력 사항을 모두 입력해주세요", preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "확인", style: .default, handler: nil)
+        alertController.addAction(okAction)
+        present(alertController, animated: true, completion: nil)
         return false
     }
     

--- a/CodeFantasia/Controller/Authentication/UserDataManageController.swift
+++ b/CodeFantasia/Controller/Authentication/UserDataManageController.swift
@@ -26,21 +26,21 @@ class UserDataManageController: UIViewController {
             portfolioTextView.text = userProfile.portfolioURL
             techStackTextView.text = userProfile.techStack.joined(separator: ", ")
             interestTextView.text = userProfile.areasOfInterest.joined(separator: ", ")
-//            if let profileImageURL = URL(string: userProfile.profileImageURL ?? "") {
-//                // 백그라운드 스레드에서 이미지 다운로드
-//                DispatchQueue.global().async {
-//                    if let data = try? Data(contentsOf: profileImageURL) {
-//                        if let image = UIImage(data: data) {
-//                            // 메인 스레드에서 UI 업데이트
-//                            DispatchQueue.main.async {
-//                                self.profileImage = image
-//                            }
-//                        }
-//                    }
+            let profileImageURL = (URL(string: userProfile.profileImageURL ?? "") ?? URL(string: ""))
+
+//            // Kingfisher를 사용하여 이미지를 다운로드
+//            KingfisherManager.shared.retrieveImage(with: profileImageURL!) { result in
+//                switch result {
+//                case .success(let imageResult):
+//                    // 이미지 다운로드 및 처리가 성공한 경우
+//                    let image = imageResult.image
+//                    self.profileImage = image
+//                    // 이제 'self.profileImage'에 이미지가 할당되었습니다.
+//                case .failure(let error):
+//                    // 이미지 다운로드 중 오류 발생한 경우
+//                    print("이미지 다운로드 오류: \(error)")
 //                }
-//            } else {
-//                // URL이 nil일 때의 처리
-//            }
+
         } else {
         }
     }

--- a/CodeFantasia/Controller/NewPost/NewPageViewController.swift
+++ b/CodeFantasia/Controller/NewPost/NewPageViewController.swift
@@ -15,7 +15,6 @@ import UIKit
 
 class NewPageViewController: UIViewController, UIImagePickerControllerDelegate, UINavigationControllerDelegate, UITextFieldDelegate, UITableViewDataSource, UITableViewDelegate {
     // MARK: - 변수선언
-
     let data: Project?
     
     init(data: Project?) {
@@ -55,7 +54,6 @@ class NewPageViewController: UIViewController, UIImagePickerControllerDelegate, 
             
             // 작성완료 버튼을 수정완료버튼으로 변경한다
             completeButton.setTitle("수정 완료", for: .normal)
-            completeButton.addTarget(self, action: #selector(EditcompleteButtonTapped), for: .touchUpInside)
         } else {
             // 새 프로젝트를 생성하는 경우
         }
@@ -600,7 +598,7 @@ class NewPageViewController: UIViewController, UIImagePickerControllerDelegate, 
         let path = "images/" + filename
         
         if let imageData = thumbnailImageView.image?.jpegData(compressionQuality: 0.3) {
-            imageStorage.upload(imageData: imageData, path: path) { imageUrl in
+            imageStorage.upload(imageData: imageData, path: path) { [self] imageUrl in
                 if let imageUrl = imageUrl {
                     print("이미지 업로드 성공")
                     
@@ -613,7 +611,7 @@ class NewPageViewController: UIViewController, UIImagePickerControllerDelegate, 
                         projectDuration: "\(projectStartDate) - \(projectEndDate)",
                         meetingType: meetingType,
                         imageUrl: imageUrl,
-                        projectID: UUID(),
+                        projectID: self.data?.projectID ?? UUID(),
                         platform: selectedPlatforms,
                         recruitmentField: recruitmentField,
                         recruitingStatus: true,
@@ -624,11 +622,10 @@ class NewPageViewController: UIViewController, UIImagePickerControllerDelegate, 
                         projectEndDate: self.projectEndDatePicker.date
                     )
                     self.dismissNewPageViewController()
+
                     if self.data?.projectID.uuidString == nil {
-                        print("ok")
                         self.projectRepository.create(project: projectInfo)
                     } else {
-                        print("cancle")
                         self.projectRepository.update(project: projectInfo, projectId: self.data?.projectID.uuidString ?? "")
                     }
                 } else {
@@ -643,101 +640,7 @@ class NewPageViewController: UIViewController, UIImagePickerControllerDelegate, 
     func convertToEnum(rawValue: String) -> Platform? {
         return Platform(rawValue: rawValue)
     }
-    //MARK: -  수정완료 함수
-    @objc func EditcompleteButtonTapped() {
-        //    let projectInfo = Project(projectTitle: "", projecSubtitle: "",techStack: [], recruitmentCount: 1,projectDescription: "", projectID: UUID(), platform: [], teamMember: [])
-        //    projectRepository.create(project: projectInfo)
-        //    print("aaa")
-        let projectTitle = titleTextField.text
-        let techLanguage = techLanguageTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let recruitmentField = recruitmentFieldTextField.text
-        let projectDescription = projectIntroTextView.text
-        let meetingType = meetingTypeTextField.text
-        let contactMethod = contactMethodTextField.text
-        
-        // TechStack 배열을 생성합니다.
-        let techStacks = techLanguage?.components(separatedBy: CharacterSet(charactersIn: "[]"))
-            .filter { !$0.isEmpty && $0 != "," }
-            .map { TechStack(technologies: [$0]) } ?? []
-        
-        // 생성된 TechStack 배열을 출력합니다.
-        print("TechStacks: \(techStacks)")
-        
-        // 출시 플랫폼 텍스트 필드에서 사용자 입력을 가져옵니다.
-        let platformInput = platformTextField.text
-        
-        // 사용자 입력을 쉼표로 분할하여 문자열 배열로 만듭니다.
-        let platformsArray = platformInput?.components(separatedBy: "/").map { $0.trimmingCharacters(in: .whitespaces) } ?? []
-        
-        // 각 텍스트를 enum 값으로 변환하여 배열에 추가합니다.
-        var selectedPlatforms: [Platform] = []
-        for platformText in platformsArray {
-            if let platform = Platform(rawValue: platformText) {
-                selectedPlatforms.append(platform)
-            }
-        }
-        
-        // DateFormatter를 사용하여 문자열로 변환
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        let projectStartDate = dateFormatter.string(from: projectStartDatePicker.date)
-        let projectEndDate = dateFormatter.string(from: projectEndDatePicker.date)
-        
-        if projectTitle?.isEmpty ?? true ||
-            techLanguage?.isEmpty ?? true ||
-            recruitmentField?.isEmpty ?? true ||
-            projectDescription?.isEmpty ?? true ||
-            meetingType?.isEmpty ?? true ||
-            contactMethod?.isEmpty ?? true ||
-            platformInput?.isEmpty ?? true
-        {
-            // 어떤 필드라도 비어 있다면 경고를 표시합니다.
-            let alertController = UIAlertController(title: "Warning!", message: "Complete your mission", preferredStyle: .alert)
-            let okAction = UIAlertAction(title: "Copy that.", style: .default, handler: nil)
-            alertController.addAction(okAction)
-            present(alertController, animated: true, completion: nil)
-            return
-        }
-        // Firebase에 데이터 업로드
-        
-        let imageStorage = ImageStorageManager()
-        let filename = UUID().uuidString
-        let path = "images/" + filename
-        
-        if let imageData = thumbnailImageView.image?.jpegData(compressionQuality: 0.3) {
-            imageStorage.upload(imageData: imageData, path: path) { imageUrl in
-                if let imageUrl = imageUrl {
-                    print("이미지 업로드 성공")
-                    
-                    let projectInfo = Project(
-                        projectTitle: projectTitle,
-                        projecSubtitle: nil,
-                        techStack: techStacks, // 여기에 techStacks 배열을 할당합니다.
-                        recruitmentCount: 1,
-                        projectDescription: projectDescription,
-                        projectDuration: "\(projectStartDate) - \(projectEndDate)",
-                        meetingType: meetingType,
-                        imageUrl: imageUrl,
-                        projectID: UUID(),
-                        platform: selectedPlatforms,
-                        recruitmentField: recruitmentField,
-                        recruitingStatus: true,
-                        teamMember: [],
-                        contactMethod: contactMethod,
-                        writerID: self.writerId,
-                        projectStartDate: self.projectStartDatePicker.date,
-                        projectEndDate: self.projectEndDatePicker.date
-                    )
-                    self.dismissNewPageViewController()
-                    self.projectRepository.create(project: projectInfo)
-                } else {
-                    print("이미지 업로드 실패!")
-                }
-            }
-        } else {
-            print("이미지 데이터가 유효하지 않습니당. 흠..")
-        }
-    }
+
     // MARK: - 모달페이지함수
    
     @objc func platformTextFieldTapped() {

--- a/CodeFantasia/Controller/NewPost/NewPageViewController.swift
+++ b/CodeFantasia/Controller/NewPost/NewPageViewController.swift
@@ -44,8 +44,8 @@ class NewPageViewController: UIViewController, UIImagePickerControllerDelegate, 
             recruitmentFieldTextField.text = project.recruitmentField
             projectIntroTextView.text = project.projectDescription
             
-            projectStartDatePicker.date = data!.projectStartDate
-            projectEndDatePicker.date = data!.projectEndDate
+            projectStartDatePicker.date = project.projectStartDate
+            projectEndDatePicker.date = project.projectEndDate
             
             thumbnailImageView.kf.setImage(with: URL(string: project.imageUrl ?? ""))
             
@@ -624,7 +624,13 @@ class NewPageViewController: UIViewController, UIImagePickerControllerDelegate, 
                         projectEndDate: self.projectEndDatePicker.date
                     )
                     self.dismissNewPageViewController()
-                    self.projectRepository.create(project: projectInfo)
+                    if self.data?.projectID.uuidString == nil {
+                        print("ok")
+                        self.projectRepository.create(project: projectInfo)
+                    } else {
+                        print("cancle")
+                        self.projectRepository.update(project: projectInfo, projectId: self.data?.projectID.uuidString ?? "")
+                    }
                 } else {
                     print("이미지 업로드 실패!")
                 }

--- a/CodeFantasia/Profile/ProfileViewController.swift
+++ b/CodeFantasia/Profile/ProfileViewController.swift
@@ -243,7 +243,6 @@ extension ProfileViewController {
             .withUnretained(self)
             .subscribe(onNext: { owner, user in
                 DispatchQueue.main.async {
-
                     self.profileImage.kf.setImage(with: URL(string: user.profileImageURL ?? "")) { result in
                         switch result {
                         case .success(_):
@@ -261,8 +260,8 @@ extension ProfileViewController {
             }, onError: { [weak self] error in
                 DispatchQueue.main.async {
                     self?.alertViewActionSheet(
-                        title: "오류 발생",
-                        message: error.localizedDescription,
+                        title: "작성된 프로필이 없습니다",
+                        message: "프로필 수정 버튼을 클릭하여 프로필을 등록해주세요.",
                         acceptText: "확인",
                         cancelText: nil
                     )
@@ -271,9 +270,9 @@ extension ProfileViewController {
             .disposed(by: disposeBag)
         
         outputs.profileEditDidTap
-            .drive (with: self, onNext: { owner, _ in
-                    let profileViewController = UserDataManageController()
-                    owner.present(profileViewController, animated: true)
+            .drive (with: self, onNext: { owner, user in
+                let profileViewController = UserDataManageController(data: owner.viewModel.userProfile)
+                        owner.present(profileViewController, animated: true)
             })
             .disposed(by: disposeBag)
         

--- a/CodeFantasia/ProjectDetailNoticeBoard/ProjectDetailNoticeBoardViewController.swift
+++ b/CodeFantasia/ProjectDetailNoticeBoard/ProjectDetailNoticeBoardViewController.swift
@@ -131,7 +131,7 @@ final class ProjectDetailNoticeBoardViewController: UIViewController {
     private lazy var reportButton = UIBarButtonItem(image: .reportImage, style: .plain, target: self, action: nil)
     private var menuItems: [UIAction] {
         return [
-            UIAction(title: "수정하기", image: UIImage(systemName: "pencil"), handler: { [weak self] _ in
+            UIAction(title: "수정하기", image: .editImage, handler: { [weak self] _ in
                 self?.alertViewAlert(title: "수정", message: "프로젝트를 수정하시겠습니까?", cancelText: "아니요", acceptCompletion: {
                     let editView = NewPageViewController(data: self?.viewModel.project)
                     editView.modalPresentationStyle = .fullScreen
@@ -351,14 +351,57 @@ extension ProjectDetailNoticeBoardViewController {
                 
                 if project.writerID == currentAuthor {
                     self.projectApplyButton.isHidden = true
-                    self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "",
-                                                                           image: UIImage(systemName: "ellipsis.circle"),
-                                                                           primaryAction: nil,
-                                                                           menu: self.editMenu)
+                    self.navigationController?.navigationBar.tintColor = UIColor.black
+                    if #available(iOS 13.0, *) {
+                        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "",
+                                                                                 image: .menuImage,
+                                                                               primaryAction: nil,
+                                                                               menu: self.editMenu)
+                          } else {
+                              self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: .menuImage,
+                                                                                       style: .plain,
+                                                                                       target: self,
+                                                                                       action: #selector(showActionSheet))
+                          }
                 } else {
                     self.navigationItem.rightBarButtonItem = self.reportButton
                 }
             })
             .disposed(by: disposeBag)
+    }
+    
+    @objc func showActionSheet(_ sender: UIBarButtonItem) {
+        let alert = UIAlertController(title: nil,
+                                      message: "액션시트",
+                                      preferredStyle: .actionSheet)
+        let editAction = UIAlertAction(title: "수정하기",
+                                         style: .default,
+                                         handler: { [weak self] _ in
+            self?.alertViewAlert(title: "수정",
+                                 message: "프로젝트를 수정하시겠습니까?",
+                                 cancelText: "아니요",
+                                 acceptCompletion: {
+                let editView = NewPageViewController(data: self?.viewModel.project)
+                editView.modalPresentationStyle = .fullScreen
+                self?.present(editView, animated: true)
+            })
+        })
+        let deleteAction = UIAlertAction(title: "삭제하기",
+                                       style: .default,
+                                       handler: { [weak self] _ in
+                                       self?.alertViewAlert(
+                                 title: "삭제",
+                                 message: "프로젝트를 삭제하시겠습니까?",
+                                 cancelText: "아니요",
+                                 acceptCompletion: {self?.viewModel.projectDeleteComplete.on(.next(()))
+            })
+        })
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: { _ in
+            self.dismiss(animated: true)
+        })
+
+        [editAction, deleteAction, cancelAction].forEach { alert.addAction($0) }
+
+        self.present(alert, animated: true, completion: nil)
     }
 }

--- a/CodeFantasia/ProjectDetailNoticeBoard/ProjectDetailNoticeBoardViewModel.swift
+++ b/CodeFantasia/ProjectDetailNoticeBoard/ProjectDetailNoticeBoardViewModel.swift
@@ -81,7 +81,6 @@ final class ProjectDetailNoticeBoardViewModel {
         .disposed(by: disposeBag)
         
         projectEditComplete.subscribe { _ in
-            self.projectRepository.update(project: self.project!)
         }
         .disposed(by: disposeBag)
         
@@ -99,7 +98,6 @@ final class ProjectDetailNoticeBoardViewModel {
                 guard let currentAuthor = Auth.auth().currentUser?.uid else {
                     return false
                 }
-                
                 return project.writerID == currentAuthor
             }.asDriver(onErrorJustReturn: false)
         )

--- a/CodeFantasia/Repository/ProjectRepository.swift
+++ b/CodeFantasia/Repository/ProjectRepository.swift
@@ -16,10 +16,11 @@ protocol ProjectRepositoryProtocol {
     func delete(project: Project)
     func `delete`(projectId: String)
     func update(project: Project)
+    func `update`(project: Project, projectId: String)
 }
 
 struct ProjectRepository: ProjectRepositoryProtocol {
-    
+
     private enum ProjectRepositoryError: LocalizedError {
         case dataConvertError
     }
@@ -77,5 +78,9 @@ struct ProjectRepository: ProjectRepositoryProtocol {
     func update(project: Project) {
         firebaseManager.update(collectionId, project.projectID.uuidString, project)
     }
-
+    
+    func `update`(project: Project, projectId: String) {
+        firebaseManager.delete(collectionId, projectId)
+    }
+    
 }

--- a/CodeFantasia/Repository/ProjectRepository.swift
+++ b/CodeFantasia/Repository/ProjectRepository.swift
@@ -80,7 +80,7 @@ struct ProjectRepository: ProjectRepositoryProtocol {
     }
     
     func `update`(project: Project, projectId: String) {
-        firebaseManager.delete(collectionId, projectId)
+        firebaseManager.update(collectionId, projectId, project)
     }
     
 }

--- a/CodeFantasia/Resource/Images.swift
+++ b/CodeFantasia/Resource/Images.swift
@@ -8,7 +8,9 @@
 import UIKit
 
 extension UIImage {
-    static let projectDeleteImage = UIImage(systemName: "trash")?.withTintColor(.black, renderingMode: .alwaysOriginal)
+    static let projectDeleteImage = UIImage(systemName: "trash")
     static let defaultProfileImage = UIImage(systemName: "person.circle")?.withTintColor(.black, renderingMode: .alwaysOriginal)
     static let reportImage = UIImage(systemName: "nosign.app")?.withTintColor(.black, renderingMode: .alwaysOriginal)
+    static let menuImage = UIImage(systemName: "ellipsis.circle")?.withTintColor(.black, renderingMode: .alwaysOriginal)
+    static let editImage = UIImage(systemName: "pencil")
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/CF-054-EmptyProfileDataAlert

### 변경 사항
-  프로필 등록 및 수정 페이지에서 입력사항 모두 완료하지 않을시 기존 닉네임과 마찬가지로 필드 Shake하게 하고 데이터 및 페이지 넘어가지 않게 했음(추가로 알럿창도 띄워줌)
-  이미 등록된 프로필이 있는 상태에서 프로필 수정 버튼 클릭시 필드에 기존 프로필 데이터 뜨게 하였음  
-  추가적으로  새글 작성시 생성되고 이미 작성된 글 수정시 업데이트하게 변경하였음(수정시 글이 2개로 추가되는 현상 해결)

### 기타 사항 

- UIMenu가 IOS14 부터 작동하는걸로 알고 있어서 그 이하 버전에는 ActionSheet로 대체하게 했음
- 실기기 테스트시 내프로젝트 페이지에서 디테일페이지로 이동시 navigationbar 파란색으로 뜨는 버그 수정 

### 테스트 결과

- 어메이징합니다

### 관련 이슈 

#132