### PR TITLE
[FEAT] 프로젝트 디테일 페이지 사용자 로고 탭시 작성자 프로필 보여주기

### DIFF
--- a/CodeFantasia/Controller/Authentication/UserDataManageController.swift
+++ b/CodeFantasia/Controller/Authentication/UserDataManageController.swift
@@ -26,8 +26,7 @@ class UserDataManageController: UIViewController {
             portfolioTextView.text = userProfile.portfolioURL
             techStackTextView.text = userProfile.techStack.joined(separator: ", ")
             interestTextView.text = userProfile.areasOfInterest.joined(separator: ", ")
-            let profileImageURL = (URL(string: userProfile.profileImageURL ?? "") ?? URL(string: ""))
-
+//            let profileImageURL = (URL(string: userProfile.profileImageURL ?? "") ?? URL(string: ""))
 //            // Kingfisher를 사용하여 이미지를 다운로드
 //            KingfisherManager.shared.retrieveImage(with: profileImageURL!) { result in
 //                switch result {

--- a/CodeFantasia/ProjectDetailNoticeBoard/ProjectDetailNoticeBoardViewController.swift
+++ b/CodeFantasia/ProjectDetailNoticeBoard/ProjectDetailNoticeBoardViewController.swift
@@ -166,7 +166,6 @@ extension ProjectDetailNoticeBoardViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-//        exchange()
         configure()
         activityIndicator.startAnimating()
     }
@@ -291,7 +290,6 @@ extension ProjectDetailNoticeBoardViewController {
         
         outputs.projectLeaderProfileDidTap
             .drive(with: self, onNext: { owner, leaderUserId in
-                // 프로필 뷰로
                 if let leaderUserId {
                     let profileViewController = ProfileViewController(viewModel: ProfileViewModel(userRepository: UserRepository(firebaseBaseManager: FireBaseManager()), userId: String(leaderUserId)))
                     owner.present(profileViewController, animated: true)
@@ -350,6 +348,7 @@ extension ProjectDetailNoticeBoardViewController {
                 }
                 
                 if project.writerID == currentAuthor {
+                    self.projectTeamLeaderProfileImageButton.isHidden = true
                     self.projectApplyButton.isHidden = true
                     self.navigationController?.navigationBar.tintColor = UIColor.black
                     if #available(iOS 13.0, *) {

--- a/CodeFantasia/ProjectDetailNoticeBoard/ProjectDetailNoticeBoardViewModel.swift
+++ b/CodeFantasia/ProjectDetailNoticeBoard/ProjectDetailNoticeBoardViewModel.swift
@@ -21,7 +21,7 @@ final class ProjectDetailNoticeBoardViewModel {
     struct Output {
         var projectDataFetched: Observable<Project>
         var projectApplyButtonDidTap: Driver<String?>
-        var projectLeaderProfileDidTap: Driver<Int?>
+        var projectLeaderProfileDidTap: Driver<String?>
         var projectReportButtonDidTap: Driver<Void>
         var userAuthConfirmed: Driver<Bool>
 //        var projectApplySuccess: Observable<Void>
@@ -90,7 +90,7 @@ final class ProjectDetailNoticeBoardViewModel {
                 self?.project?.contactMethod
             },
             projectLeaderProfileDidTap: input.profileImageTapped.map { [weak self] _ in
-                self?.project?.teamMember.first(where: {$0.category == Role(detailRole: "leader")})?.employeeID
+                self?.project?.writerID
             },
             projectReportButtonDidTap: input.projectReportButtonTapped,
             


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/CF-054-EmptyProfileDataAlert

### 변경 사항

- 프로젝트 디테일 페이지에서 다른 사용자가 작성한 글에서 사용자 로고를 탭할 경우 작성자의 프로필을 보여주게끔 했음
-  작성자 프로필로 들어갈시 로그아웃 및 프로필 수정 버튼 숨김 처리 했음
-  내가 작성한 글에서는 사용자 로고 숨김 처리 했음

### 기타 사항 

### 테스트 결과

https://github.com/CodeFantasia/iOS/assets/139093066/1be61331-b473-476b-8b20-b89ca05ad535


https://github.com/CodeFantasia/iOS/assets/139093066/26a1da3f-2c88-460e-b7d0-7a52b2831443


### 관련 이슈 

#137