### PR TITLE
feat: 중복이메일 확인 버그 수정

### DIFF
--- a/CodeFantasia/Controller/Authentication/SignUp/RegistrationController.swift
+++ b/CodeFantasia/Controller/Authentication/SignUp/RegistrationController.swift
@@ -8,7 +8,7 @@ class RegistrationController: UIViewController {
 
     // MARK: - Properties
     
-    private var isDuplicate = false
+    private var isDuplicate = true
     
     private let titleLabel: UILabel = {
         let label = UILabel()
@@ -66,6 +66,7 @@ class RegistrationController: UIViewController {
     
     private let emailTextField: UITextField = {
         let textfield = Utilities().textField(withPlaceholder: "Email")
+        textfield.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         return textfield
     }()
     
@@ -156,6 +157,10 @@ class RegistrationController: UIViewController {
       }
     
     // MARK: - Selectors
+    
+    @objc func textFieldDidChange() {
+        isDuplicate = true 
+    }
     
     @objc func handleEmailDuplicateCheck() {
         guard let email = emailTextField.text, emailVerify(email: email) else { return }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/CF-065-Duplicate

### 변경 사항
회원가입 시 중복 확인 안 하고 넘어갈 수 없도록 수정했습니다.
이메일에 입력한 내용이 바뀔 시 중복 확인을 다시 하도록 했습니다.

### 기타 사항 

### 테스트 결과

### 관련 이슈 
#163 
